### PR TITLE
Feature #011 Chapter04

### DIFF
--- a/guestbook/src/main/java/org/zerock/guestbook/controller/GuestbookController.java
+++ b/guestbook/src/main/java/org/zerock/guestbook/controller/GuestbookController.java
@@ -54,7 +54,7 @@ public class GuestbookController {
         return "redirect:/guestbook/list";
     }
 
-    @GetMapping("/read")
+    @GetMapping({"/read", "/modify"})
     public void read(long gno, @ModelAttribute("requestDTO") PageRequestDTO requestDTO, Model model) {
 
         log.info("gno: " + gno);
@@ -62,6 +62,34 @@ public class GuestbookController {
         GuestbookDTO dto = service.read(gno);
 
         model.addAttribute("dto", dto);
+
+    }
+
+    @PostMapping("/modify")
+    public String modify(GuestbookDTO dto, @ModelAttribute("requestDTO") PageRequestDTO requestDTO, RedirectAttributes redirectAttributes) {
+
+        log.info("post modify...........................");
+        log.info("dto: " + dto);
+
+        service.modify(dto);
+
+        redirectAttributes.addAttribute("page", requestDTO.getPage());
+        redirectAttributes.addAttribute("gno", dto.getGno());
+
+        return "redirect:/guestbook/read";
+
+    }
+
+    @PostMapping("/remove")
+    public String remove(long gno, RedirectAttributes redirectAttributes) {
+
+        log.info("gno: " + gno);
+
+        service.remove(gno);
+
+        redirectAttributes.addFlashAttribute("msg", gno);
+
+        return "redirect:/guestbook/list";
 
     }
 }

--- a/guestbook/src/main/java/org/zerock/guestbook/service/GuestbookService.java
+++ b/guestbook/src/main/java/org/zerock/guestbook/service/GuestbookService.java
@@ -12,6 +12,10 @@ public interface GuestbookService {
 
     GuestbookDTO read(Long gno);
 
+    void remove(Long gno);
+
+    void modify(GuestbookDTO dto);
+
     default Guestbook dtoToEntity(GuestbookDTO dto) {
         Guestbook entity = Guestbook.builder()
                 .gno(dto.getGno())

--- a/guestbook/src/main/java/org/zerock/guestbook/service/GuestbookServiceImpl.java
+++ b/guestbook/src/main/java/org/zerock/guestbook/service/GuestbookServiceImpl.java
@@ -56,4 +56,28 @@ public class GuestbookServiceImpl implements GuestbookService {
 
         return result.isPresent() ? entityToDto(result.get()) : null;
     }
+
+    @Override
+    public void remove(Long gno) {
+
+        repository.deleteById(gno);
+
+    }
+
+    @Override
+    public void modify(GuestbookDTO dto) {
+
+        Optional<Guestbook> result = repository.findById(dto.getGno());
+
+        if (result.isPresent()) {
+
+            Guestbook entity = result.get();
+
+            entity.changeTitle(dto.getTitle());
+            entity.changeContent(dto.getContent());
+
+            repository.save(entity);
+
+        }
+    }
 }

--- a/guestbook/src/main/resources/templates/guestbook/modify.html
+++ b/guestbook/src/main/resources/templates/guestbook/modify.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+
+<th:block th:replace="~{/layout/basic :: setContent(~{this::content})}">
+
+    <th:block th:fragment="content">
+
+        <h1 class="mt-4">GuestBook Modify Page</h1>
+
+        <form action="/guestbook/modify" method="post">
+
+            <!-- 페이지 번호 -->
+            <input type="hidden" name="page" th:value="${requestDTO.page}">
+
+            <div class="form-group">
+                <label>Gno</label>
+                <input type="text" class="form-control" name="gno" th:value="${dto.gno}" readonly>
+            </div>
+
+            <div class="form-group">
+                <label>Title</label>
+                <input type="text" class="form-control" name="title" th:value="${dto.title}">
+            </div>
+
+            <div class="form-group">
+                <label>Content</label>
+                <textarea class="form-control" rows="5" name="content">[[${dto.content}]]</textarea>
+            </div>
+
+            <div class="form-group">
+                <label>Writer</label>
+                <input type="text" class="form-control" name="writer" th:value="${dto.writer}" readonly>
+            </div>
+
+            <div class="form-group">
+                <label>RegDate</label>
+                <input type="text" class="form-control" th:value="${#temporals.format(dto.regDate, 'yyyy/MM/dd HH:mm:ss')}" readonly>
+            </div>
+
+            <div class="form-group">
+                <label>ModDate</label>
+                <input type="text" class="form-control" th:value="${#temporals.format(dto.modDate, 'yyyy/MM/dd HH:mm:ss')}" readonly>
+            </div>
+
+        </form>
+
+        <button type="button" class="btn btn-primary modifyBtn">Modify</button>
+
+        <button type="button" class="btn btn-info listBtn">List</button>
+
+        <button type="button" class="btn btn-danger removeBtn">Remove</button>
+
+        <script th:inline="javascript">
+
+            var actionForm = $("form");
+
+            $(".removeBtn").click(function() {
+                actionForm
+                    .attr("action", "/guestbook/remove")
+                    .attr("method", "post");
+
+                actionForm.submit();
+            });
+
+            $(".modifyBtn").click(function() {
+                if (!confirm("수정하시겠습니까?")) {
+                    return;
+                }
+
+                actionForm
+                    .attr("action", "/guestbook/modify")
+                    .attr("method", "post")
+                    .submit();
+            });
+
+            $(".listBtn").click(function() {
+                var pageInfo = $("input[name='page']");
+
+                actionForm.empty();
+                actionForm.append(pageInfo);
+                actionForm
+                    .attr("action", "/guestbook/list")
+                    .attr("method", "get");
+
+                console.log(actionForm.html());
+                actionForm.submit();
+            });
+
+        </script>
+
+    </th:block>
+
+</th:block>
+
+</html>


### PR DESCRIPTION
## 개요
Part2 Chapter04 - 9. 방명록의 수정/삭제 처리 완료

## 작업내용
- GuestbookController 클래스 수정
  - 기존 read()의 annotation 변경 : "/read" -> {"/read", "/modify"}
  - 삭제를 위해 POST 방식의 remove() 메서드 추가
  - 수정을 위해 POST 방식의 modify() 메서드 추가
- modify.html 작성
  - 틀은 기존 read.html과 동일
  - title과 content 항목은 수정이 가능하도록 수정
  - 하단에 Modify, List, Remove 버튼으로 구성
  - 각 버튼 클릭 시 동작하도록 작성
- GuestbookService 인터페이스 수정
  - remove()와 modify() 메서드 추가
- GuestbookServiceImpl 클래스 수정
  - remove()와 modify() 메서드 구현